### PR TITLE
Select Menu

### DIFF
--- a/internal/lua/bindings/new_button.go
+++ b/internal/lua/bindings/new_button.go
@@ -21,7 +21,6 @@ func (b *NewButtonBinding) Name() string {
 
 func (b *NewButtonBinding) SetSession(session *discordgo.Session) {}
 
-// Register adds the `register_application_command` function to a Lua table.
 func (b *NewButtonBinding) Register(L *lua.LState) *lua.LFunction {
 	slog.Info("Registering new button command Lua function")
 	return L.NewFunction(func(L *lua.LState) int {

--- a/internal/lua/bindings/new_select_menu.go
+++ b/internal/lua/bindings/new_select_menu.go
@@ -1,0 +1,60 @@
+package bindings
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	lua "github.com/yuin/gopher-lua"
+)
+
+type NewSelectMenuBinding struct{}
+
+// NewNewSelectMenuBinding initializes a new NewSelectMenuBinding.
+func NewNewSelectMenuBinding() *NewSelectMenuBinding {
+	return &NewSelectMenuBinding{}
+}
+
+// Name returns the name of the Lua global table for this binding.
+func (b *NewSelectMenuBinding) Name() string {
+	return "new_selectmenu"
+}
+
+func (b *NewSelectMenuBinding) SetSession(session *discordgo.Session) {}
+
+func (b *NewSelectMenuBinding) Register(L *lua.LState) *lua.LFunction {
+	slog.Info("Registering new select menu command Lua function")
+	return L.NewFunction(func(L *lua.LState) int {
+		argCount := L.GetTop()
+		selectTable := L.NewTable()
+
+		if argCount == 3 {
+			selectTable.RawSetString("placeholder", lua.LString(L.CheckString(1)))
+			selectTable.RawSetString("custom_id", lua.LString(L.CheckString(2)))
+			selectTable.RawSetString("disabled", lua.LFalse)
+			selectTable.RawSetString("options", L.CheckTable(3))
+		} else if argCount == 4 {
+			selectTable.RawSetString("placeholder", lua.LString(L.CheckString(1)))
+			selectTable.RawSetString("custom_id", lua.LString(L.CheckString(2)))
+			selectTable.RawSetString("options", L.CheckTable(3))
+			selectTable.RawSetString("disabled", lua.LBool(L.CheckBool(4)))
+		} else {
+			L.ArgError(1, "invalid arguments, expected (name, custom_id [, disabled])")
+		}
+
+		// Create a Table for the button
+		selectTable.RawSetString("type", lua.LString("select"))
+
+		L.Push(selectTable)
+		return 1
+	})
+}
+
+// HandleInteraction is not applicable for this binding.
+func (b *NewSelectMenuBinding) HandleInteraction(L *lua.LState, interaction *discordgo.InteractionCreate) error {
+	// This binding does not handle interactions
+	return nil
+}
+
+func (b *NewSelectMenuBinding) CanHandleInteraction(interaction *discordgo.InteractionCreate) bool {
+	return false
+}

--- a/internal/lua/bindings/new_select_menu_option.go
+++ b/internal/lua/bindings/new_select_menu_option.go
@@ -1,0 +1,43 @@
+package bindings
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	lua "github.com/yuin/gopher-lua"
+)
+
+type NewSelectMenuOptionBinding struct{}
+
+// NewNewSelectMenuOptionBinding initializes a new NewSelectMenuOptionBinding.
+func NewNewSelectMenuOptionBinding() *NewSelectMenuOptionBinding {
+	return &NewSelectMenuOptionBinding{}
+}
+
+// Name returns the name of the Lua global table for this binding.
+func (b *NewSelectMenuOptionBinding) Name() string {
+	return "new_selectmenu_opt"
+}
+
+func (b *NewSelectMenuOptionBinding) SetSession(session *discordgo.Session) {}
+
+func (b *NewSelectMenuOptionBinding) Register(L *lua.LState) *lua.LFunction {
+	slog.Info("Registering new select menu command Lua function")
+	return L.NewFunction(func(L *lua.LState) int {
+		optTable := L.NewTable()
+		optTable.RawSetString("label", lua.LString(L.CheckString(1)))
+		optTable.RawSetString("value", lua.LString(L.CheckString(2)))
+		L.Push(optTable)
+		return 1
+	})
+}
+
+// HandleInteraction is not applicable for this binding.
+func (b *NewSelectMenuOptionBinding) HandleInteraction(L *lua.LState, interaction *discordgo.InteractionCreate) error {
+	// This binding does not handle interactions
+	return nil
+}
+
+func (b *NewSelectMenuOptionBinding) CanHandleInteraction(interaction *discordgo.InteractionCreate) bool {
+	return false
+}

--- a/internal/lua/bindings/register_interaction.go
+++ b/internal/lua/bindings/register_interaction.go
@@ -116,6 +116,18 @@ func (b *InteractionEventBinding) executeHandler(L *lua.LState, interaction *dis
 			dataTable.RawSetString(key, lua.LString(value))
 		}
 		interactionTable.RawSetString("data", dataTable)
+	} else {
+		interactionTable.RawSetString("data", lua.LNil)
+	}
+
+	if interaction.MessageComponentData().Values != nil {
+		valuesTable := L.NewTable()
+		for _, value := range interaction.MessageComponentData().Values {
+			valuesTable.Append(lua.LString(value))
+		}
+		interactionTable.RawSetString("values", valuesTable)
+	} else {
+		interactionTable.RawSetString("values", lua.LNil)
 	}
 
 	// Call the Lua function

--- a/internal/lua/lua_manager.go
+++ b/internal/lua/lua_manager.go
@@ -63,6 +63,8 @@ func (m *LuaManager) RegisterBindings(session *discordgo.Session, guildID string
 			bindings.NewApplicationCommandBinding(guildID),
 			bindings.NewInteractionEventBinding(),
 			bindings.NewNewButtonBinding(),
+			bindings.NewNewSelectMenuBinding(),
+			bindings.NewNewSelectMenuOptionBinding(),
 		},
 		"timer": {
 			bindings.NewRunAfterBinding(),

--- a/internal/lua/utils/parse_components.go
+++ b/internal/lua/utils/parse_components.go
@@ -35,6 +35,45 @@ func ParseComponents(_ *lua.LState, table *lua.LTable) ([]discordgo.MessageCompo
 				Style:    discordgo.PrimaryButton, // Default style
 				Disabled: disabled,
 			})
+		case "select":
+			placeholder := componentTable.RawGetString("placeholder").String()
+			customID := componentTable.RawGetString("custom_id").String()
+
+			disabled := false
+			disabledRaw := componentTable.RawGetString("disabled")
+			if disabledRaw.Type() == lua.LTBool {
+				disabled = lua.LVAsBool(disabledRaw)
+			}
+
+			optionsRaw := componentTable.RawGetString("options")
+			options, ok := optionsRaw.(*lua.LTable)
+			if !ok {
+				return // Skip invalid entries
+			}
+
+			var selectOptions []discordgo.SelectMenuOption
+			options.ForEach(func(_, value lua.LValue) {
+				optionTable, ok := value.(*lua.LTable)
+				if !ok {
+					return // Skip invalid entries
+				}
+
+				optLabel := optionTable.RawGetString("label").String()
+				optValue := optionTable.RawGetString("value").String() // custom id
+
+				selectOptions = append(selectOptions, discordgo.SelectMenuOption{
+					Label: optLabel,
+					Value: optValue,
+				})
+			})
+
+			components = append(components, discordgo.SelectMenu{
+				Placeholder: placeholder,
+				CustomID:    customID,
+				Options:     selectOptions,
+				Disabled:    disabled,
+			})
+
 		default:
 			return
 		}

--- a/lua/driftwood.lua
+++ b/lua/driftwood.lua
@@ -41,7 +41,8 @@ local driftwood = {
 --- EventInteraction class for handling event interactions (e.g., custom IDs).
 --- Extends the base Interaction class and includes data.
 --- @class EventInteraction : InteractionBase
---- @field data table<string, string> Parsed regex groups from the custom ID.
+--- @field data table<string, string>|nil Parsed regex groups from the custom ID.
+--- @field values string[]|nil The values selected in a select menu.
 
 --- InteractionReplyOptions class for defining reply options.
 --- @class InteractionReplyOptions
@@ -71,6 +72,11 @@ local driftwood = {
 --- @field required? boolean Whether the option is required (default: false).
 --- @field options? CommandOption[] Optional sub-options for subcommands.
 --- @field handler? fun(interaction: CommandInteraction) Optional handler for subcommands.
+
+--- SelectOption class for defining options within select menus.
+--- @class SelectOption
+--- @field label string The label of the option.
+--- @field value string The value of the option.
 
 --- State Management
 
@@ -118,6 +124,20 @@ function driftwood.log.error(message) end
 --- @param disabled? boolean Optional flag to disable the button.
 --- @return InteractionComponents button The new button component.
 function driftwood.new_button(label, custom_id, disabled) end
+
+--- Create a new instance of a select menu option.
+--- @param label string The label of the option.
+--- @param value string The custom ID for the option.
+--- @return SelectOption opt The new select menu option.
+function driftwood.new_selectmenu_opt(label, value) end
+
+--- Create a new instance of a select menu in an action row.
+--- @param placeholder string The placeholder text for the select menu.
+--- @param custom_id string The custom ID for the select menu.
+--- @param options SelectOption[] The options for the select menu.
+--- @param disabled boolean Whether the select menu is disabled.
+--- @return InteractionComponents selectmenu The new select menu component.
+function driftwood.new_selectmenu(placeholder, custom_id, options, disabled) end
 
 --- Options Functions
 

--- a/lua/message_demo.lua
+++ b/lua/message_demo.lua
@@ -65,6 +65,12 @@ end
 --- Handles the "md:button:value" interaction.
 --- @param interaction EventInteraction The interaction object from Discord.
 local function handle_button_click(interaction)
+    -- Check if not null
+    if interaction.data == nil then
+        interaction:reply("No data found in the interaction.", { ephemeral = true })
+        return
+    end
+
     local value = interaction.data.value
     if value then
         interaction:reply("Button clicked with value: " .. value, { ephemeral = true })

--- a/lua/selectmenu.lua
+++ b/lua/selectmenu.lua
@@ -1,0 +1,61 @@
+local driftwood = require("driftwood")
+
+--- Dumps a table to a string.
+---@param tbl table The table to dump.
+---@return string The table as a string.
+local function dump(tbl)
+    if type(tbl) == 'table' then
+       local s = '{ '
+       for k,v in pairs(tbl) do
+          if type(k) ~= 'number' then k = '"'..k..'"' end
+          s = s .. '['..k..'] = ' .. dump(v) .. ','
+       end
+       return s .. '} '
+    else
+       return tostring(tbl)
+    end
+end
+
+--- Handles the "selectmenu_demo" application command.
+--- @param interaction CommandInteraction The interaction object from Discord.
+local function handle_selectmenu(interaction)
+    local message_id = driftwood.message.add(interaction.channel_id, "Testing the select menu", {
+        driftwood.new_selectmenu("Select an option", "md:selectmenu:initial", {
+            driftwood.new_selectmenu_opt("Option 1", "option1"),
+            driftwood.new_selectmenu_opt("Option 2", "option2"),
+        }, false),
+    })
+
+    if not message_id then
+        interaction:reply("Failed to send message.", { ephemeral = true })
+        return
+    end
+
+    interaction:reply("Message sent!", { ephemeral = true })
+
+end
+
+--- Register the /message_demo command.
+driftwood.register_application_command({
+    name = "seletmenu_demo",
+    description = "Demonstrates message management with a select menu.",
+    handler = handle_selectmenu
+})
+
+--- Register the interaction to handle "md:selectmenu:initial".
+driftwood.register_interaction("md:selectmenu:initial", function(interaction)
+    -- Check if not null
+    if interaction.values == nil then
+        interaction:reply("No value found in the interaction.", { ephemeral = true })
+        return
+    end
+
+    local value = interaction.values[1]
+    if value == "option1" then
+        interaction:reply("Option 1 selected!", { ephemeral = true })
+    elseif value == "option2" then
+        interaction:reply("Option 2 selected!", { ephemeral = true })
+    else
+        interaction:reply("Unknown option selected!" .. dump(interaction.values), { ephemeral = true })
+    end
+end)


### PR DESCRIPTION
Add the select menu input for action rows. This has added a new value to the `register_interaction` callback, `interaction.values` which is a string array. There is an example usage in `./lua/selectmenu.lua`.