### PR TITLE
Reaction Support

### DIFF
--- a/internal/lua/bindings/message/del.go
+++ b/internal/lua/bindings/message/del.go
@@ -1,7 +1,6 @@
 package message
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/bwmarrin/discordgo"
@@ -37,11 +36,11 @@ func (b *MessageBindingDelete) Register(L *lua.LState) *lua.LFunction {
 		err := b.Session.ChannelMessageDelete(channelID, messageID)
 		if err != nil {
 			slog.Error("Failed to delete message", "message_id", messageID, "channel_id", channelID, "error", err)
-			L.Push(lua.LString(fmt.Sprintf("Failed to delete message: %s", err.Error())))
+			L.Push(lua.LFalse)
 			return 1
 		}
 
-		L.Push(lua.LString("Message deleted successfully"))
+		L.Push(lua.LTrue)
 		return 1
 	})
 }

--- a/internal/lua/bindings/message/edit.go
+++ b/internal/lua/bindings/message/edit.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"driftwood/internal/lua/utils"
-	"fmt"
 	"log/slog"
 
 	"github.com/bwmarrin/discordgo"
@@ -93,11 +92,11 @@ func (b *MessageBindingEdit) Register(L *lua.LState) *lua.LFunction {
 		})
 		if err != nil {
 			slog.Error("Failed to edit message", "message_id", messageID, "channel_id", channelID, "error", err)
-			L.Push(lua.LString(fmt.Sprintf("Failed to edit message: %s", err.Error())))
+			L.Push(lua.LFalse)
 			return 1
 		}
 
-		L.Push(lua.LString("Message edited successfully"))
+		L.Push(lua.LTrue)
 		return 1
 	})
 }

--- a/internal/lua/bindings/reaction/add.go
+++ b/internal/lua/bindings/reaction/add.go
@@ -1,0 +1,57 @@
+package reaction
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// ReactionBindingAdd provides Lua bindings for add reactions to Discord messages.
+type ReactionBindingAdd struct {
+	Session *discordgo.Session
+}
+
+// NewReactionBindingAdd initializes a new reaction add instance.
+func NewReactionBindingAdd() *ReactionBindingAdd {
+	slog.Debug("Creating new ReactionBindingAdd")
+	return &ReactionBindingAdd{}
+}
+
+// Name returns the name of the binding.
+func (b *ReactionBindingAdd) Name() string {
+	return "add"
+}
+
+func (b *ReactionBindingAdd) SetSession(session *discordgo.Session) {
+	b.Session = session
+}
+
+// Register registers the reaction-related functions in the Lua state.
+func (b *ReactionBindingAdd) Register(L *lua.LState) *lua.LFunction {
+	return L.NewFunction(func(L *lua.LState) int {
+		messageID := L.CheckString(1)
+		channelID := L.CheckString(2)
+		content := L.CheckString(3)
+
+		err := b.Session.MessageReactionAdd(channelID, messageID, content)
+		if err != nil {
+			slog.Error("Failed to react to message", "message_id", messageID, "channel_id", channelID, "error", err)
+			L.Push(lua.LFalse)
+			return 1
+		}
+
+		L.Push(lua.LTrue)
+		return 1
+	})
+}
+
+// HandleInteraction is not applicable for this binding.
+func (b *ReactionBindingAdd) HandleInteraction(L *lua.LState, interaction *discordgo.InteractionCreate) error {
+	// This binding does not handle interactions
+	return nil
+}
+
+func (b *ReactionBindingAdd) CanHandleInteraction(interaction *discordgo.InteractionCreate) bool {
+	return false
+}

--- a/internal/lua/bindings/reaction/remove.go
+++ b/internal/lua/bindings/reaction/remove.go
@@ -1,0 +1,57 @@
+package reaction
+
+import (
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// ReactionBindingRemove provides Lua bindings for Remove reactions to Discord messages.
+type ReactionBindingRemove struct {
+	Session *discordgo.Session
+}
+
+// NewReactionBindingRemove initializes a new reaction Remove instance.
+func NewReactionBindingRemove() *ReactionBindingRemove {
+	slog.Debug("Creating new ReactionBindingRemove")
+	return &ReactionBindingRemove{}
+}
+
+// Name returns the name of the binding.
+func (b *ReactionBindingRemove) Name() string {
+	return "remove"
+}
+
+func (b *ReactionBindingRemove) SetSession(session *discordgo.Session) {
+	b.Session = session
+}
+
+// Register registers the reaction-related functions in the Lua state.
+func (b *ReactionBindingRemove) Register(L *lua.LState) *lua.LFunction {
+	return L.NewFunction(func(L *lua.LState) int {
+		messageID := L.CheckString(1)
+		channelID := L.CheckString(2)
+		content := L.CheckString(3)
+
+		err := b.Session.MessageReactionsRemoveEmoji(channelID, messageID, content)
+		if err != nil {
+			slog.Error("Failed to react to message", "message_id", messageID, "channel_id", channelID, "error", err)
+			L.Push(lua.LFalse)
+			return 1
+		}
+
+		L.Push(lua.LTrue)
+		return 1
+	})
+}
+
+// HandleInteraction is not applicable for this binding.
+func (b *ReactionBindingRemove) HandleInteraction(L *lua.LState, interaction *discordgo.InteractionCreate) error {
+	// This binding does not handle interactions
+	return nil
+}
+
+func (b *ReactionBindingRemove) CanHandleInteraction(interaction *discordgo.InteractionCreate) bool {
+	return false
+}

--- a/internal/lua/lua_manager.go
+++ b/internal/lua/lua_manager.go
@@ -15,6 +15,7 @@ import (
 	"driftwood/internal/lua/bindings"
 	bindings_message "driftwood/internal/lua/bindings/message"
 	bindings_options "driftwood/internal/lua/bindings/options"
+	bindings_reaction "driftwood/internal/lua/bindings/reaction"
 	bindings_state "driftwood/internal/lua/bindings/state"
 
 	"driftwood/internal/lua/utils"
@@ -82,6 +83,10 @@ func (m *LuaManager) RegisterBindings(session *discordgo.Session, guildID string
 			bindings_message.NewMessageBindingAdd(),
 			bindings_message.NewMessageBindingEdit(),
 			bindings_message.NewMessageBindingDelete(),
+		},
+		"reaction": {
+			bindings_reaction.NewReactionBindingAdd(),
+			bindings_reaction.NewReactionBindingRemove(),
 		},
 		"option": {
 			bindings_options.NewNewOptionStringBinding(),

--- a/lua/driftwood.lua
+++ b/lua/driftwood.lua
@@ -12,6 +12,7 @@ local driftwood = {
     log = {},
     option = {},
     message = {},
+    reaction = {},
     channel = {},
 }
 
@@ -215,6 +216,23 @@ function driftwood.message.edit(message_id, channel_id, content, options) end
 --- @param channel_id string The ID of the channel containing the message.
 --- @return boolean success Whether the deletion was successful.
 function driftwood.message.delete(message_id, channel_id) end
+
+--- Reaction Functions
+--- These functions provide support for adding and removing reactions on messages.
+
+--- Add a reaction to a message.
+--- @param message_id string The ID of the message to react to.
+--- @param channel_id string The ID of the channel where the message is located.
+--- @param reaction_emoji string The emoji to add as a reaction.
+--- @return boolean success Whether the reaction was successfully added.
+function driftwood.reaction.add(message_id, channel_id, reaction_emoji) end
+
+--- Remove a reaction from a message.
+--- @param message_id string The ID of the message from which to remove the reaction.
+--- @param channel_id string The ID of the channel where the message is located.
+--- @param reaction_emoji string The emoji to remove as a reaction.
+--- @return boolean success Whether the reaction was successfully removed.
+function driftwood.reaction.remove(message_id, channel_id, reaction_emoji) end
 
 
 --- Channel Functions

--- a/lua/votey_thumbs.lua
+++ b/lua/votey_thumbs.lua
@@ -1,0 +1,30 @@
+local driftwood = require("driftwood")
+
+--- Register the /voteythumbs command
+driftwood.register_application_command({
+    name = "voteythumbs",
+    description = "Respectfully debate things that probably don't matter",
+    options = {
+        {
+            name = "question",
+            description = "The topic of debate",
+            type = driftwood.option_string,
+            required = true,
+        },
+    },
+    handler = function(interaction)
+      
+        local question = interaction.options.question
+        local message_id = driftwood.message.add(interaction.channel_id, question)
+        if not message_id then
+            interaction:reply("Failed to send message.", { ephemeral = true })
+            return
+        end
+      
+        driftwood.reaction.add(message_id, interaction.channel_id, "👍")
+        driftwood.reaction.add(message_id, interaction.channel_id, "👎")
+
+        interaction:reply("Your vote has been setup!", { ephemeral = true })
+      
+    end,
+})


### PR DESCRIPTION
Closes #5 

This PR implements the basic reaction adding and removing to the bindings. There is also a `voteythumbs` example in the `lua` directory. 